### PR TITLE
Add playlist tracks retrieval and update model annotations

### DIFF
--- a/src/main/java/io/NextGenAudio/Playlist/Service/controller/PlaylistController.java
+++ b/src/main/java/io/NextGenAudio/Playlist/Service/controller/PlaylistController.java
@@ -2,6 +2,7 @@ package io.NextGenAudio.Playlist.Service.controller;
 
 import io.NextGenAudio.Playlist.Service.service.PlaylistService;
 import io.NextGenAudio.Playlist.Service.model.Playlist;
+import io.NextGenAudio.Playlist.Service.model.PlaylistMusic;
 import io.NextGenAudio.Playlist.Service.dto.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -47,6 +48,18 @@ public class PlaylistController {
         try {
             Playlist playlist = playlistService.getPlaylist(playlistId, getCurrentUserId());
             return ResponseEntity.ok(playlist);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.notFound().build();
+        } catch (SecurityException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+    }
+
+    @GetMapping("/{playlistId}/tracks")
+    public ResponseEntity<List<PlaylistMusic>> getPlaylistTracks(@PathVariable Integer playlistId) {
+        try {
+            List<PlaylistMusic> tracks = playlistService.getPlaylistTracks(playlistId, getCurrentUserId());
+            return ResponseEntity.ok(tracks);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.notFound().build();
         } catch (SecurityException e) {

--- a/src/main/java/io/NextGenAudio/Playlist/Service/model/Playlist.java
+++ b/src/main/java/io/NextGenAudio/Playlist/Service/model/Playlist.java
@@ -1,5 +1,7 @@
 package io.NextGenAudio.Playlist.Service.model;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -7,6 +9,7 @@ import java.util.UUID;
 
 @Entity
 @Table(name = "playlists")
+@JsonIgnoreProperties("tracks")
 public class Playlist {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,6 +47,7 @@ public class Playlist {
     private OffsetDateTime updatedAt;
 
     @OneToMany(mappedBy = "playlist", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JsonManagedReference
     private List<PlaylistMusic> tracks;
 
     // Constructors

--- a/src/main/java/io/NextGenAudio/Playlist/Service/model/PlaylistMusic.java
+++ b/src/main/java/io/NextGenAudio/Playlist/Service/model/PlaylistMusic.java
@@ -1,5 +1,6 @@
 package io.NextGenAudio.Playlist.Service.model;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import java.time.OffsetDateTime;
 
@@ -50,4 +51,13 @@ public class PlaylistMusic {
 
     public OffsetDateTime getAddedAt() { return addedAt; }
     public void setAddedAt(OffsetDateTime addedAt) { this.addedAt = addedAt; }
+
+    @Override
+    public String toString() {
+        return "PlaylistMusic{" +
+                "id=" + id +
+                ", musicId=" + musicId +
+                ", position=" + position +
+                '}';
+    }
 }

--- a/src/main/java/io/NextGenAudio/Playlist/Service/service/PlaylistService.java
+++ b/src/main/java/io/NextGenAudio/Playlist/Service/service/PlaylistService.java
@@ -37,6 +37,12 @@ public class PlaylistService {
         return playlist;
     }
 
+    public List<PlaylistMusic> getPlaylistTracks(Integer playlistId, UUID userId) {
+        // Verify user has access to the playlist
+        getPlaylist(playlistId, userId);
+        return playlistMusicRepository.findByPlaylist_PlaylistIdOrderByPositionAsc(playlistId);
+    }
+
     public Playlist updatePlaylist(Integer playlistId, String name, UUID userId) {
         Playlist playlist = getPlaylist(playlistId, userId);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,7 @@ spring.datasource.hikari.max-lifetime=1800000
 
 # ============ JPA/Hibernate Configuration ============
 # Temporarily use 'create-drop' to fix schema issues, then change back to 'validate'
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
- Implemented `getPlaylistTracks` method in `PlaylistService` to fetch tracks for a given playlist.
- Added `getPlaylistTracks` endpoint in `PlaylistController`.
- Updated `Playlist` and `PlaylistMusic` models with appropriate JSON annotations.
- Changed Hibernate DDL auto setting to 'none' in `application.properties` for schema stability.